### PR TITLE
Overhaul requirements parsing (#3, #8, #9)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    name: Python ${{ matrix.python-version}}
+    steps:
+      - uses: actions/checkout@v3.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Update pip and install dev requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Test
+        run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,6 @@ commands = pytest {posargs} tests/
 basepython = python3.8
 changedir = {toxinidir}
 commands =
-    black --check pip_stale tests
+    black --diff pip_stale tests
     ruff pip_stale tests
 """

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -3,7 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from click.testing import CliRunner
+import pytest
 import responses
+from rich.console import Console
 
 from pip_stale import main
 
@@ -17,3 +19,42 @@ def test_it_runs():
         env={"COLUMNS": "100"},
     )
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "specs, expected",
+    [
+        (["tomli"], [("tomli", "==0.0.0")]),
+        (["tomli==1.0.0"], [("tomli", "==1.0.0")]),
+        # Handle comments correctly
+        (
+            [
+                "# NOTE(willkg): we need this until we're Python > 3.7",
+                "importlib_resources==6.1.0",
+            ],
+            [("importlib_resources", "==6.1.0")],
+        ),
+        # Handle blank lines
+        (
+            [
+                "    ",
+                "importlib_resources==6.1.0",
+                "",
+            ],
+            [("importlib_resources", "==6.1.0")],
+        ),
+        # Handle environment markers (ignore them)
+        (
+            ["tomli>=2.0.1; python_version < '3.11'"],
+            [("tomli", ">=2.0.1")],
+        ),
+        (
+            ["black==23.9.1; implementation_name == 'cpython'"],
+            [("black", "==23.9.1")],
+        ),
+    ],
+)
+def test_parse_and_check(specs, expected):
+    console = Console()
+    reqs = list(main.parse_requirements(specs, console=console))
+    assert [(req.name, str(req.specifier)) for req in reqs] == expected


### PR DESCRIPTION
This overhauls requirements parsing removing our parser in favor of the
packaging library parser. That fixes the issue pip-stale had in
issue #8. This adds tests for requirements parsing.

This also changes the table so it uses box.MARKDOWN which is more
copy/paste friendly. That's issue #9.

This also adds a verbose mode.

This adds CI. But it probably has to land first to enable CI.

Fixes #8. Fixes #9.